### PR TITLE
Improve build_kernel.sh

### DIFF
--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -92,7 +92,11 @@ toolchain() {
 		echo -e "${YELLOW}Warning: Toolchains need different Operating Systems!${NC}\n"
 		echo -e "${YELLOW}Check below if your System are compatible before u Continue.${NC}\n"
 		echo -e "${GREEN}Your current OS is: $DISTRO - GLIBC: $GLIBC_VERSION${NC}\n"
-		if [[ "$DISTRO" == "Ubuntu 23.10" ]]; then
+		if [[ "$DISTRO" == "Ubuntu 24.04 LTS" ]]; then
+			echo -e "${YELLOW}➜ Neutron needs ${GREEN}Ubuntu 23.10/24.04 [GLIBC2.38]${NC}"
+			echo -e "${YELLOW}Vortex needs ${RED}Ubuntu 21.10 [GLIBC2.34]${NC}"
+			echo -e "${YELLOW}Proton needs ${RED}Ubuntu 20.04 [GLIBC2.31]${NC}"
+		elif [[ "$DISTRO" == "Ubuntu 23.10" ]]; then
 			echo -e "${YELLOW}➜ Neutron needs ${GREEN}Ubuntu 23.10 [GLIBC2.38]${NC}"
 			echo -e "${YELLOW}Vortex needs ${RED}Ubuntu 21.10 [GLIBC2.34]${NC}"
 			echo -e "${YELLOW}Proton needs ${RED}Ubuntu 20.04 [GLIBC2.31]${NC}"
@@ -110,7 +114,16 @@ toolchain() {
 		select toolchain in "Yes" "Exit"; do
 			case $toolchain in
 			"Yes")
-				if [[ "$DISTRO" == "Ubuntu 23.10" ]]; then
+				if [[ "$DISTRO" == "Ubuntu 24.04 LTS" ]]; then
+					echo -e "${YELLOW}Downloading Neutron-Clang Toolchain ...${NC}\n"
+					mkdir -p "$HOME/toolchains/neutron-clang"
+					cd "$HOME/toolchains/neutron-clang"
+					bash <(curl -s "https://raw.githubusercontent.com/Neutron-Toolchains/antman/main/antman") -S
+					cd "$SRCTREE"
+					cp -r "$HOME/toolchains/neutron-clang" toolchain
+					clear
+					select_device
+				elif [[ "$DISTRO" == "Ubuntu 23.10" ]]; then
 					echo -e "${YELLOW}Downloading Neutron-Clang Toolchain ...${NC}\n"
 					mkdir -p "$HOME/toolchains/neutron-clang"
 					cd "$HOME/toolchains/neutron-clang"

--- a/build_kernel.sh
+++ b/build_kernel.sh
@@ -200,7 +200,8 @@ build_kernel() {
 		LD_LIBRARY_PATH="$LD:$LD_LIBRARY_PATH" \
 		CLANG_TRIPLE=$TRIPLE \
 		CROSS_COMPILE=$CROSS \
-		CROSS_COMPILE_ARM32=$CROSS_ARM32
+		CROSS_COMPILE_ARM32=$CROSS_ARM32 \
+		&> compilelog.txt
 	echo -e "${NC}"
 	clear
 	echo -e "${YELLOW}Creating ZIP for $codename ...${NC}\n"


### PR DESCRIPTION
This generic build script is helpful across multiple different kernel.
compilelog.txt for monitoring errors has been added and ubuntu 24.04 support